### PR TITLE
Update sort.md

### DIFF
--- a/docs/examples/sort.md
+++ b/docs/examples/sort.md
@@ -64,11 +64,11 @@ function qw_example_sort_options($sort_options)
  * But this is what it looks like if you were to do it yourself
  *
  *  @param  &$args - The WP_Query arguments we are building
- *  @param  $filter - This filter's settings and values
-                      Values stored in $filter['values']
+ *  @param  $sort - This sort's settings and values
+                    Values stored in $sort['values']
  */
 function qw_sort_example_query_args(&$args, $sort){
   $args[$sort['orderby_key']] = $sort['type'];
-  $args[$sort['order_key']] = $sort['order_value'];
+  $args[$sort['order_key']] = $sort['values']['order_value'];
 }
 ````


### PR DESCRIPTION
$sort['order_value'] returns null rather than the option selected in the UI. Updating to $sort['values']['order_value'] seems to do the trick. This may not be the best solution, but figure I'd share a bug and proposed fix. Also updating the @param notes to reflect sort rather than filter. Other updates may be necessary, for example the comment on line 48 referencing defaults. 