### PR TITLE
Update taxonomy_terms.php

### DIFF
--- a/includes/fields/taxonomy_terms.php
+++ b/includes/fields/taxonomy_terms.php
@@ -35,12 +35,14 @@ function qw_field_taxonomy_terms_output( $post, $field ) {
 
 	$terms = get_the_terms( $post->ID, $field['taxonomy_name'] );
 
-	foreach( $terms as $term ){
-		if ( isset( $field['link_to_term'] ) ) {
-			$output[] = '<a href="' . get_term_link( $term->term_id ) . '">' . $term->name . '</a>';
-		}
-		else {
-			$output[] = $term->name;
+	if ( $terms ) {
+		foreach( $terms as $term ){
+			if ( isset( $field['link_to_term'] ) ) {
+				$output[] = '<a href="' . get_term_link( $term->term_id ) . '">' . $term->name . '</a>';
+			}
+			else {
+				$output[] = $term->name;
+			}
 		}
 	}
 


### PR DESCRIPTION
If a post is returned without any taxonomy terms selected, the following warning appears on the front end, "Warning: Invalid argument supplied for foreach() in /app/web/wp-content/plugins/query-wrangler/includes/fields/taxonomy_terms.php on line 42". Another approach would be to check if there are no terms and return prior to the foreach, which would prevent any markup from rendering.