### PR TITLE
Meta keys cache life

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -155,9 +155,16 @@ function qw_update_query( $post ) {
 			$query_id ) );
 	} // update for widgets
 	else {
-		$wpdb->query( $wpdb->prepare( "UPDATE {$table_name} SET data = %s WHERE id = %d LIMIT 1", 
-			$new_data, 
+		$wpdb->query( $wpdb->prepare( "UPDATE {$table_name} SET data = %s WHERE id = %d LIMIT 1",
+			$new_data,
 			$query_id ) );
+	}
+
+	// Refresh meta_keys_cache.
+	$settings = QW_Settings::get_instance();
+	if ($settings->get('meta_key_cache_life') !== 'none') {
+		delete_transient('query_wrangler_meta_keys_cache');
+		qw_get_meta_keys();
 	}
 }
 
@@ -407,7 +414,7 @@ function qw_meta_key_autocomplete() {
 
 		$results = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT(`meta_key`) FROM {$wpdb->postmeta} WHERE `meta_key` LIKE '%s' LIMIT 15",
 			'%' . $meta_key . '%' ) );
-		
+
 		//foreach ($query)
 		wp_send_json( array(
 			'success' => TRUE,

--- a/admin/query-admin-pages.php
+++ b/admin/query-admin-pages.php
@@ -222,6 +222,7 @@ function qw_save_settings( $post ) {
 	$show_silent_meta = ( isset( $post['qw-show-silent-meta'] ) ) ? $post['qw-show-silent-meta'] : '';
 	$meta_value_field_handler = ( isset( $post['qw-meta-value-field-handler'] ) ) ? $post['qw-meta-value-field-handler'] : '';
 	$shortcode_compat = isset( $post['qw-shortcode-compat'] ) ? $post['qw-shortcode-compat'] : '';
+	$meta_key_cache_life = $post['qw-meta-keys-cache-life'] ?? 'forever';
 
 	$settings = QW_Settings::get_instance();
 	$settings->set( 'edit_theme', $post['qw-theme'] );
@@ -230,6 +231,7 @@ function qw_save_settings( $post ) {
 	$settings->set( 'show_silent_meta', $show_silent_meta );
 	$settings->set( 'meta_value_field_handler', $meta_value_field_handler );
 	$settings->set( 'shortcode_compat', $shortcode_compat );
+	$settings->set('meta_key_cache_life', $meta_key_cache_life);
 	$settings->save();
 }
 

--- a/admin/templates/form-settings.php
+++ b/admin/templates/form-settings.php
@@ -1,3 +1,16 @@
+<?php
+/**
+ * @var string $edit_theme
+ * @var bool $widget_theme_compat
+ * @var bool $live_preview
+ * @var bool $show_silent_meta
+ * @var bool $shortcode_compat
+ * @var string $meta_value_field_handler
+ * @var string $meta_key_cache_life
+ * @var array[] $edit_themes
+ * @var array $meta_value_field_options
+ */
+?>
 <form id="qw-edit-settings"
       action="<?php print admin_url( 'admin.php?page=query-wrangler&action=save_settings&noheader=true' ); ?>"
       method='post'>
@@ -12,11 +25,10 @@
 					theme.</p>
 				<select name="qw-theme">
 					<?php
-					foreach ( $edit_themes as $key => $edit_theme ) { ?>
+					foreach ( $edit_themes as $key => $theme ) { ?>
 						<option
-							value="<?php print $key; ?>" <?php selected( $key,
-							$theme ); ?>>
-							<?php print $edit_theme['title']; ?>
+							value="<?php print $key; ?>" <?php selected( $key, $edit_theme ); ?>>
+							<?php print $theme['title']; ?>
 						</option>
 					<?php
 					}
@@ -78,12 +90,10 @@
 				<select name="qw-meta-value-field-handler">
 					<?php
 					foreach ( $meta_value_field_options as $value => $text ) { ?>
-						<option
-							value="<?php print $value; ?>" <?php selected( $value,
-							$meta_value_field_handler ); ?>>
+						<option value="<?php print $value; ?>" <?php selected( $value, $meta_value_field_handler ); ?>>
 							<?php print $text; ?>
 						</option>
-					<?php
+						<?php
 					}
 					?>
 				</select>
@@ -94,6 +104,37 @@
 					<li><b>New</b> - a generic "Custom field" is available in
 						the UI, and you must provide it the meta key.
 					</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th>
+				<label>Meta Keys Cache Life</label>
+			</th>
+			<td>
+				<p class="description">
+					Discovering meta keys can be very expensive and time-consuming query for large sites.
+					It's recommended to enable <em>some</em> amount of caching on this.
+				</p>
+				<?php
+				$meta_key_cache_options = [
+					'none' => '- ' . __('No Caching') . ' -',
+					3600 => __('1 Hour'),
+					DAY_IN_SECONDS => __('1 Day'),
+					WEEK_IN_SECONDS => __('1 Week'),
+					0 => __('Forever'),
+				];
+				?>
+				<select name="qw-meta-keys-cache-life">
+					<?php foreach ( $meta_key_cache_options as $value => $label ) { ?>
+						<option value="<?= esc_attr($value) ?>" <?php selected($value, $meta_key_cache_life) ?>>
+							<?= esc_html( $label ) ?>
+						</option>
+					<?php } ?>
+				</select>
+				<ul>
+					<li><b>No Caching</b> - Never cache meta keys. This could cause performance issues.</li>
+					<li><b>Forever</b> - Cache meta keys until a Query Wrangler Query is edited and saved.</li>
 				</ul>
 			</td>
 		</tr>

--- a/includes/class-qw-settings.php
+++ b/includes/class-qw-settings.php
@@ -49,7 +49,7 @@ class QW_Settings {
 	 * @param $key
 	 * @param bool|FALSE $default
 	 *
-	 * @return bool
+	 * @return mixed
 	 */
 	function get( $key, $default = false ){
 		if ( isset( $this->values[ $key ] ) ){

--- a/includes/class-qw-settings.php
+++ b/includes/class-qw-settings.php
@@ -11,6 +11,7 @@ class QW_Settings {
 		'show_silent_meta'         => 0,
 		'meta_value_field_handler' => 0,
 		'shortcode_compat'         => 0,
+		'meta_key_cache_life'      => 0, // Forever.
 	);
 
 	public $values = array();

--- a/includes/query.php
+++ b/includes/query.php
@@ -469,13 +469,21 @@ function qw_make_form_prefix( $type, $name ) {
  * @return array All meta keys in WP
  */
 function qw_get_meta_keys() {
-	global $wpdb;
+	$settings = QW_Settings::get_instance();
+	$cache_life = $settings->get('meta_key_cache_life');
 
-	$keys = $wpdb->get_col( "
-			SELECT meta_key
+	$keys = get_transient('query_wrangler_meta_keys_cache');
+	if (!$keys || $cache_life === 'none') {
+		global $wpdb;
+
+		$keys = $wpdb->get_col( "
+			SELECT DISTINCT(meta_key)
 			FROM $wpdb->postmeta
-			GROUP BY meta_key
 			ORDER BY meta_key" );
+
+		set_transient('query_wrangler_meta_keys_cache', $keys, (int) $cache_life);
+	}
+
 
 	return $keys;
 }


### PR DESCRIPTION
Resolves #23 by adding a new setting that allows site admin to control the cache life of the meta_keys.

The default cache life is "forever", and it automatically refreshes itself each time a query is saved.