### PR TITLE
Account for post_type in the query_vars to be an array for post type archive override.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -74,6 +74,10 @@ Select a category or multiple categories to override.   Save the query, then vis
 
 == Changelog ==
 
+= 1.5.53 =
+
+* Bug fix on post type archive override page when dealing with multiple post types.
+
 = 1.5.52 =
 
 * New setting to allow caching of meta keys.
@@ -393,4 +397,4 @@ Select a category or multiple categories to override.   Save the query, then vis
 
 == Upgrade Notice ==
 
-1.5.52 Major bug fix and new setting for caching meta_keys.
+1.5.53 Bug fix on post type archive override page when dealing with multiple post types.

--- a/query-wrangler.php
+++ b/query-wrangler.php
@@ -9,7 +9,7 @@ Plugin URI:        https://www.daggerhart.com
 Description:       Query Wrangler provides an intuitive interface for creating complex WP queries as pages or widgets. Based on Drupal Views.
 Author:            Jonathan Daggerhart
 Author URI:        http://daggerhart.com
-Version:           1.5.52
+Version:           1.5.53
 
 ******************************************************************
 
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 // some useful definitions
-define( 'QW_VERSION', 1.552 );
+define( 'QW_VERSION', 1.553 );
 define( 'QW_PLUGIN_DIR', dirname( __FILE__ ) );
 define( 'QW_PLUGIN_URL', plugins_url( '', __FILE__ ) );
 define( 'QW_DEFAULT_THEME', 'views' );


### PR DESCRIPTION
Issue: https://wordpress.org/support/topic/illegal-offset-type-in-isset-or-empty-in-post_type_archive-php