### PR TITLE
Fix php warning thrown when post types filter is empty

### DIFF
--- a/includes/filters/post_types.php
+++ b/includes/filters/post_types.php
@@ -171,13 +171,11 @@ function qw_filter_post_types_exposed_form_checkboxes( $filter, &$values ) {
 		<?php
 		// List all categories as checkboxes
 		foreach ( $post_types as $type ) {
-			if ( is_array( $filter['values']['post_types'] ) ) {
-				// see if our submitted value is
-				if ( in_array( $type, $filter['values']['post_types'] ) ) {
-					$type_checked = 'checked="checked"';
-				} else {
-					$type_checked = '';
-				}
+			// see if our submitted value is
+			if ( is_array( $filter['values']['post_types'] ) && in_array( $type, $filter['values']['post_types'] ) ) {
+				$type_checked = 'checked="checked"';
+			} else {
+				$type_checked = '';
 			}
 			?>
 			<label class="query-checkbox">


### PR DESCRIPTION
If no post types are selected via the post_types filter, the following warning/notice would be thrown, PHP Warning:  Undefined variable $type_checked in /wp-content/plugins/query-wrangler/includes/filters/post_types.php on line 187