### PR TITLE
Fix passing of incorrect param to update_query function

### DIFF
--- a/admin/query-admin-pages.php
+++ b/admin/query-admin-pages.php
@@ -15,7 +15,7 @@ function qw_page_handler() {
 			case 'update':
 				$query_id = $_GET['edit'];
 				check_admin_referer( 'qw-edit_' . $query_id );
-				qw_update_query( $query_id );
+				qw_update_query( $_POST );
 				// redirect to the edit page
 				qw_admin_redirect( $query_id );
 				break;


### PR DESCRIPTION
A recent update changed a call from `qw_update_query( $_POST );` to `qw_update_query( $query_id );`, but `qw_update_query( $post )` expects and array or $_POST data, not a post ID resulting in critical error when trying to update/save.
```
Fatal error: Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, string given in .../plugins/query-wrangler/admin/admin.php:107
```